### PR TITLE
Remove random div tag

### DIFF
--- a/controllers/cms_settings/stats.htm
+++ b/controllers/cms_settings/stats.htm
@@ -20,10 +20,6 @@
 			<?= backend_button('Cancel', url('system/settings')) ?>
 			
 			<input type="hidden" id="prev_pageviews" value="<?= $settings->keep_pageviews ?>"/>
-<div id="booty">
-	uo
-</div>
-
 			<div class="clear"></div>
 		</form>
 		


### PR DESCRIPTION
Not sure why this div tag was included but it just adds 'uo' beside the cancel button at the bottom of the Settings - Statistics form.
